### PR TITLE
Update _ into G_ for Guile 3 (Lily 2.25)

### DIFF
--- a/shapeII/module.ily
+++ b/shapeII/module.ily
@@ -201,7 +201,7 @@ shapeII =
                  (notehead-placement coords spec side))
                 (else (begin
                        (ly:programming-error
-                        (_ "unknown control-point instruction type: ~a\nUsing default coordinates for control-point ~a.")
+                        (G_ "unknown control-point instruction type: ~a\nUsing default coordinates for control-point ~a.")
                         spec
                         (+ which-point 1))
                        coords))))))


### PR DESCRIPTION
Avoid error message for “unknown syntactic keyword”